### PR TITLE
Introduced gh-actions to automate chart publishing

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,17 @@
+name: Helm Publish
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: J12934/helm-gh-pages-action@master
+        with:
+          access-token: ${{ secrets.ACCESS_TOKEN }}
+          deploy-branch: gh-pages
+          charts-folder: deployments


### PR DESCRIPTION
Hi Nick,

this github action automates publishing of the helm chart to the gh-pages branch. If you would like to use it you have to create a secret called ACCESS_TOKEN which contains a repo access token.

Cheers